### PR TITLE
Fixed counter issues, should start from 1 instead of 0

### DIFF
--- a/detector.py
+++ b/detector.py
@@ -556,7 +556,7 @@ class Detector():
             return
         print("Will expand each mask by {} pixels".format(dilation/2))
 
-        file_counter = 0
+        file_counter = 1
         if(is_video == True):
             # support for multiple videos if your computer can even handle that
             vid_list = []


### PR DESCRIPTION
Was using this amazing tool and while this is a minor issue, the file counter variable should start from 1 instead of 0. To most non-programmers, "0 out of 5 files" wouldn't make much sense. 